### PR TITLE
Add ability to obtain unreleased amiibo fabrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Features
+
+- The Princess Zelda Fabric can be obtained from the BotW Zelda amiibo.
+- The Gerudo-King Fabric can be obtained from the Smash Bros. Ganondorf amiibo.
+
 ## [1.1.0] - 2023-05-17
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Hyrule, while "Depths" means you must visit The Depths at least once.
 
 | Item                   | Probability | Requirement |
 | ---------------------- | ----------: | ----------- |
-| Hyrule-Princess Fabric |        100% | None        |
+| Hyrule-Princess Fabric |         50% | None        |
+| Princess Zelda Fabric  |         50% | None        |
 
 ### Daruk
 
@@ -283,10 +284,11 @@ Hyrule, while "Depths" means you must visit The Depths at least once.
 
 ### Smash Bros. Ganondorf
 
-| Item              | Probability | Requirement |
-| ----------------- | ----------: | ----------- |
-| Demon King Fabric |         50% | None        |
-| Dusk Claymore     |         50% | Depths      |
+| Item               | Probability | Requirement |
+| ------------------ | ----------: | ----------- |
+| Demon King Fabric  |         34% | None        |
+| Gerudo-King Fabric |         33% | None        |
+| Dusk Claymore      |         33% | Depths      |
 
 ### Unknown, Possibly Unreleased Ganondorf
 

--- a/src/tables/AmiiboSetting.game__ui__AmiiboSetting.yml
+++ b/src/tables/AmiiboSetting.game__ui__AmiiboSetting.yml
@@ -187,12 +187,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 3
     MinNumberOfDropChance: 2
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_28, DropGameData: '', IsCheclDropGameData: false, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_28, DropGameData: '', IsCheclDropGameData: false, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_28, DropGameData: '', IsCheclDropGameData: false, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_28, DropGameData: '', IsCheclDropGameData: false, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -880,15 +882,17 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_35, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 50,
+    - {ActorNameShort: Obj_SubstituteCloth_35, Probability: 34, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 33, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 33,
       TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_35, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 50,
+    - {ActorNameShort: Obj_SubstituteCloth_35, Probability: 34, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 33, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 33,
       TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1


### PR DESCRIPTION
This PR adds the ability to obtain the Princess Zelda Fabric from the BotW Zelda amiibo and the Gerudo-King Fabric from the Smash Bros. Ganondorf amiibo.