### PR TITLE
Ensure useful items after rare ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Features
+
+- All drop tables have been updated to ensure chests contain weapons, bows, or
+  shields after obtaining rare items.
+
 ## [1.2.0] - 2023-05-18
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - All drop tables have been updated to ensure chests contain weapons, bows, or
   shields after obtaining rare items.
+- Progression requirements have been removed, so all items can be acquired as
+  soon as amiibo can be used.
 
 ## [1.2.0] - 2023-05-18
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ from amiibo chests.
 
 ## What
 
-No Loot Boxes ensures that amiibo chests will always contain a rare item if you
-would normally be eligible for one. For example, if you use the Skyward Sword
-Zelda amiibo, then the amiibo chest is guaranteed to contain the Goddess Fabric.
+No Loot Boxes ensures that amiibo chests will contain a rare item if you would
+normally be eligible for one. For example, if you use the Skyward Sword Zelda
+amiibo, then the amiibo chest is guaranteed\* to contain the Goddess Fabric.
 
 ## Why
 
@@ -57,16 +57,14 @@ just get the rare amiibo items without the grind.
 ## How
 
 This mod alters the drop tables for amiibo so that all non-zero probabilities of
-receiving a rare item are raised to 100%. In other words, if you're at a point
-in the game where you _could_ receive a rare item from an amiibo, then you
-_will_.
+receiving a rare item are raised to near 100%. In other words, if you're at a
+point in the game where you _could_ receive a rare item from an amiibo, then you
+_will_.\*
 
-This mod does not give you rare items that are normally locked behind
-progression requirements, however. For example, in order to have a chance at
-receiving Sheik's Mask from the Smash Bros. Sheik amiibo, you must complete the
-Great Sky Island. With this mod, you still have to complete the Great Sky
-Island, but you're guarateed to get either Sheik's Mask or the Sheik Fabric each
-time you use the amiibo after that.
+\* Due to how the drop tables are configured, there is a small chance that you
+will not receive a rare item. This is to ensure that once you receive the rare
+item, like the fabric or armor set, you will continue to receive useful items
+like weapons, bows, and shields when you use the amiibo.
 
 ## Installation
 
@@ -91,8 +89,8 @@ Open Ryujinx. Right-click Tears of the Kingdom > Open Mods Directory. Copy the
 
 ## Compatibility
 
-This mod was tested with Tears of the Kingdom v1.1.0. Your mileage may vary with
-other versions of the game.
+This mod was tested with Tears of the Kingdom v1.1.0 and v1.1.1. Your mileage
+may vary with other versions of the game.
 
 This mod is not compatible with any mod that alters
 `romfs/Pack/ResidentCommon.pack.zs`.
@@ -110,194 +108,168 @@ This way I will be immediately notified. I don't check sites like GameBanana and
 Nexus Mods every day, and I don't receive email notifications from them, so if
 you post something there, I might not see it for weeks for even months.
 
-## Drop Tables
+## Drops
 
-These are the new amiibo drop tables as updated by this mod. For the Requirement
-column, "Hyrule" means you must complete the Great Sky Island and have access to
-Hyrule, while "Depths" means you must visit The Depths at least once.
+These are the chest items that amiibo will drop with this mod. Items in **bold**
+should appear first. Once you have obtained all **bold** items, you should begin
+receiving the rest of the items. Items marked with ✨ are weapons that have not
+been corrupted by gloom.
 
 ### Tears of the Kingdom Link
 
-| Item                       | Probability | Requirement |
-| -------------------------- | ----------: | ----------- |
-| Champion's Leathers Fabric |        100% | None        |
+- **Champion's Leathers Fabric**
+- Knight's Broadsword✨
 
 ### Breath of the Wild Archer Link
 
-| Item                     | Probability | Requirement |
-| ------------------------ | ----------: | ----------- |
-| Tunic of Memories Fabric |        100% | None        |
+- **Tunic of Memories Fabric**
+- Knight's Bow
+- Ancient Blade
 
 ### Breath of the Wild Rider Link
 
-| Item               | Probability | Requirement |
-| ------------------ | ----------: | ----------- |
-| Hylian-Hood Fabric |        100% | None        |
+- **Hylian-Hood Fabric**
+- Soldier's Broadsword✨
 
 ### Breath of the Wild Zelda
 
-| Item                   | Probability | Requirement |
-| ---------------------- | ----------: | ----------- |
-| Hyrule-Princess Fabric |         50% | None        |
-| Princess Zelda Fabric  |         50% | None        |
+- **Hyrule-Princess Fabric**
+- **Princess Zelda Fabric**
+- Royal Shield
 
 ### Daruk
 
-| Item                    | Probability | Requirement |
-| ----------------------- | ----------: | ----------- |
-| Goron-Champion Fabric   |         50% | None        |
-| Vah Rudania Divine Helm |         50% | Hyrule      |
+- **Goron-Champion Fabric**
+- **Vah Rudania Divine Helm**
+- Cobble Crusher✨
 
 ### Revali
 
-| Item                  | Probability | Requirement |
-| --------------------- | ----------: | ----------- |
-| Rito-Champion Fabric  |         50% | None        |
-| Vah Medoh Divine Helm |         50% | Hyrule      |
+- **Rito-Champion Fabric**
+- **Vah Medoh Divine Helm**
+- Falcon Bow
 
 ### Mipha
 
-| Item                 | Probability | Requirement |
-| -------------------- | ----------: | ----------- |
-| Zora-Champion Fabric |         50% | None        |
-| Vah Ruta Divine Helm |         50% | Hyrule      |
+- **Zora-Champion Fabric**
+- **Vah Ruta Divine Helm**
+- Zora Spear✨
 
 ### Urbosa
 
-| Item                    | Probability | Requirement |
-| ----------------------- | ----------: | ----------- |
-| Gerudo-Champion Fabric  |         50% | None        |
-| Vah Naboris Divine Helm |         50% | Hyrule      |
+- **Gerudo-Champion Fabric**
+- **Vah Naboris Divine Helm**
+- Gerudo Scimitar✨
+- Gerudo Shield
 
 ### Guardian
 
-| Item                   | Probability | Requirement |
-| ---------------------- | ----------: | ----------- |
-| Ancient Sheikah Fabric |        100% | None        |
+- **Ancient Sheikah Fabric**
+- Ancient Blade
 
 ### Bokoblin
 
-| Item            | Probability | Requirement |
-| --------------- | ----------: | ----------- |
-| Bokoblin Fabric |        100% | None        |
+- **Bokoblin Fabric**
+- Spiked Boko Bow
+- Spiked Boko Shield
 
 ### Link's Awakening Link
 
-| Item                  | Probability | Requirement |
-| --------------------- | ----------: | ----------- |
-| Egg Fabric            |         25% | None        |
-| Mask of Awakening     |         25% | Hyrule      |
-| Tunic of Awakening    |         25% | Hyrule      |
-| Trousers of Awakening |         25% | Hyrule      |
+- **Egg Fabric**
+- **Mask of Awakening**
+- **Tunic of Awakening**
+- **Trousers of Awakening**
+- Soldier's Broadsword✨
 
 ### Skyward Sword Link
 
-| Item                   | Probability | Requirement |
-| ---------------------- | ----------: | ----------- |
-| Sword-Spirit Fabric    |         20% | None        |
-| Cap of the Sky         |         20% | Hyrule      |
-| Tunic of the Sky       |         20% | Hyrule      |
-| Trousers of the Sky    |         20% | Hyrule      |
-| White Sword of the Sky |         20% | Depths      |
+- **Sword-Spirit Fabric**
+- **Cap of the Sky**
+- **Tunic of the Sky**
+- **Trousers of the Sky**
+- White Sword of the Sky
 
 ### Skyward Sword Zelda
 
-| Item           | Probability | Requirement |
-| -------------- | ----------: | ----------- |
-| Goddess Fabric |        100% | None        |
+- **Goddess Fabric**
+- Knight's Bow
 
 ### Twilight Princess Link / Smash Bros. Link
 
-| Item                      | Probability | Requirement |
-| ------------------------- | ----------: | ----------- |
-| Mirror of Twilight Fabric |         25% | None        |
-| Cap of Twilight           |         25% | Hyrule      |
-| Tunic of Twilight         |         25% | Hyrule      |
-| Trousers of Twilight      |         25% | Hyrule      |
+- **Mirror of Twilight Fabric**
+- **Cap of Twilight**
+- **Tunic of Twilight**
+- **Trousers of Twilight**
+- Knight's Broadsword✨
+- Knight's Shield
 
 ### Wolf Link
 
-| Item                      | Probability | Requirement |
-| ------------------------- | ----------: | ----------- |
-| Mirror of Twilight Fabric |        100% | None        |
+- **Mirror of Twilight Fabric**
+- Knight's Broadsword✨
 
 ### Wind Waker Link / Smash Bros. Toon Link
 
-| Item                     | Probability | Requirement |
-| ------------------------ | ----------: | ----------- |
-| King of Red Lions Fabric |         20% | None        |
-| Cap of the Wind          |         20% | Hyrule      |
-| Tunic of the Wind        |         20% | Hyrule      |
-| Trousers of the Wind     |         20% | Hyrule      |
-| Sea-Breeze Boomerang     |         20% | Depths      |
+- **King of Red Lions Fabric**
+- **Cap of the Wind**
+- **Tunic of the Wind**
+- **Trousers of the Wind**
+- Sea-Breeze Boomerang
 
 ### Wind Waker Zelda
 
-| Item                | Probability | Requirement |
-| ------------------- | ----------: | ----------- |
-| Bygone-Royal Fabric |         50% | None        |
-| Hero's Shield       |         50% | Depths      |
+- **Bygone-Royal Fabric**
+- Hero's Shield
 
 ### Ocarina of Time Link / Smash Bros. Young Link
 
-| Item                 | Probability | Requirement |
-| -------------------- | ----------: | ----------- |
-| Lon Lon Ranch Fabric |         20% | None        |
-| Cap of Time          |         20% | Hyrule      |
-| Tunic of Time        |         20% | Hyrule      |
-| Trousers of Time     |         20% | Hyrule      |
-| Biggoron's Sword     |         20% | Depths      |
+- **Lon Lon Ranch Fabric**
+- **Cap of Time**
+- **Tunic of Time**
+- **Trousers of Time**
+- Biggoron's Sword
 
 ### Majora's Mask Link
 
-| Item                 | Probability | Requirement |
-| -------------------- | ----------: | ----------- |
-| Majora's Mask Fabric |         20% | None        |
-| Fierce Deity Mask    |         20% | Hyrule      |
-| Fierce Deity Armor   |         20% | Hyrule      |
-| Fierce Deity Boots   |         20% | Hyrule      |
-| Fierce Deity Sword   |         20% | Depths      |
+- **Majora's Mask Fabric**
+- **Fierce Deity Mask**
+- **Fierce Deity Armor**
+- **Fierce Deity Boots**
+- Fierce Deity Sword
 
 ### 8-Bit Link
 
-| Item                 | Probability | Requirement |
-| -------------------- | ----------: | ----------- |
-| Pixel Fabric         |         20% | None        |
-| Cap of the Hero      |         20% | Hyrule      |
-| Tunic of the Hero    |         20% | Hyrule      |
-| Trousers of the Hero |         20% | Hyrule      |
-| Sword of the Hero    |         20% | Depths      |
+- **Pixel Fabric**
+- **Cap of the Hero**
+- **Tunic of the Hero**
+- **Trousers of the Hero**
+- Sword of the Hero
 
 ### Smash Bros. Zelda
 
-| Item                        | Probability | Requirement |
-| --------------------------- | ----------: | ----------- |
-| Princess of Twilight Fabric |         50% | None        |
-| Dusk Bow                    |         50% | Depths      |
+- **Princess of Twilight Fabric**
+- Dusk Bow
 
 ### Smash Bros. Sheik
 
-| Item         | Probability | Requirement |
-| ------------ | ----------: | ----------- |
-| Sheik Fabric |         50% | None        |
-| Sheik's Mask |         50% | Hyrule      |
+- **Sheik Fabric**
+- **Sheik's Mask**
+- Eightfold Blade✨
+- Shield of the Mind's Eye
+- Phrenic Bow
 
 ### Smash Bros. Ganondorf
 
-| Item               | Probability | Requirement |
-| ------------------ | ----------: | ----------- |
-| Demon King Fabric  |         34% | None        |
-| Gerudo-King Fabric |         33% | None        |
-| Dusk Claymore      |         33% | Depths      |
+- **Demon King Fabric**
+- **Gerudo-King Fabric**
+- Dusk Claymore
 
 ### Unknown, Possibly Unreleased Ganondorf
 
-| Item               | Probability | Requirement |
-| ------------------ | ----------: | ----------- |
-| Gerudo-King Fabric |        100% | None        |
+- **Gerudo-King Fabric**
+- Gloom Sword
 
 ### Unknown, Possibly Unreleased Zelda
 
-| Item                  | Probability | Requirement |
-| --------------------- | ----------: | ----------- |
-| Princess Zelda Fabric |        100% | None        |
+- **Princess Zelda Fabric**
+- Soldier's Broadsword✨

--- a/src/tables/AmiiboSetting.game__ui__AmiiboSetting.yml
+++ b/src/tables/AmiiboSetting.game__ui__AmiiboSetting.yml
@@ -24,12 +24,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_51, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_51, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_51, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_51, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -48,12 +50,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_166, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_166, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -83,12 +87,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_002, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_002, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -122,12 +128,16 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_26, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_26, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_035, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Weapon_01, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_26, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_26, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_035, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Weapon_01, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -154,12 +164,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_27, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_27, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_002, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_27, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_27, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_002, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -187,14 +199,16 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 3
     MinNumberOfDropChance: 2
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_28, DropGameData: '', IsCheclDropGameData: false, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_28, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_022, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_28, DropGameData: '', IsCheclDropGameData: false, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_28, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_52, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_022, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -212,28 +226,20 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_200_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_059, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_200_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_059, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -260,28 +266,20 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_225_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_41, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_060, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_41, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_060, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_225_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_41, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_060, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_41, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_060, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -298,28 +296,20 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 4
     MinNumberOfDropChance: 2
   - DropActorInfo:
-    - {ActorNameShort: Armor_215_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_45, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Sword_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_45, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_057, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_215_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_45, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Sword_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_45, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_057, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -336,28 +326,20 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 3
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_230_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_46, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Sword_058, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_46, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_058, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_230_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_46, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Sword_058, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_46, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_058, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -383,24 +365,22 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_210_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 25,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Upper, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_210_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 25,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Upper, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -426,24 +406,22 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_210_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 25,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Upper, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_210_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 25,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Upper, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -470,28 +448,20 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_205_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Sword_059, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_205_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Sword_059, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -509,28 +479,20 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_200_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_059, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_200_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_059, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -547,24 +509,20 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 3
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_1096_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_48, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_002, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_1096_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_48, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_002, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -592,16 +550,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_43, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Shield_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_43, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_057, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_43, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Shield_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_43, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_057, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -630,16 +586,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_39, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Bow_072, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_39, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_072, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_39, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Bow_072, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_39, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_072, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -667,12 +621,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_49, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_49, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_035, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_49, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_49, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_035, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -701,28 +657,20 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_205_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Sword_059, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_205_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Upper, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Lower, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
-      Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 20, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Sword_059, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -750,16 +698,20 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_220_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_37, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_37, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_220_Head, Probability: 48, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_041, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_041, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_029, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_220_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_37, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_37, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_220_Head, Probability: 48, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_041, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_041, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_029, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -788,17 +740,17 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Weapon_Sword_113, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
+    - {ActorNameShort: Weapon_Sword_112, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
       Probability: 30, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_113, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
+    - {ActorNameShort: Weapon_Lsword_112, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
       Probability: 30, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Spear_113, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
+    - {ActorNameShort: Weapon_Spear_112, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true,
       Probability: 30, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Sword_003, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
+    - {ActorNameShort: Weapon_Sword_002, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
       TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_003, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
+    - {ActorNameShort: Weapon_Lsword_002, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
       TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Spear_003, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
+    - {ActorNameShort: Weapon_Spear_002, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 20,
       TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
@@ -844,14 +796,18 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Item_Ore_F, Probability: 40, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Item_Ore_E, Probability: 10, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Item_Ore_D, Probability: 10, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Item_Ore_C, Probability: 10, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Item_Ore_B, Probability: 10, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Item_Ore_A, Probability: 5, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Item_Ore_J, Probability: 5, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Item_Ore_G, Probability: 10, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Ore_F, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Ore_E, Probability: 18, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Ore_D, Probability: 5, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Ore_C, Probability: 5, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Ore_B, Probability: 5, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Ore_A, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Ore_J, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Ore_G, Probability: 5, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_002, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 20,
+      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_035, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 15,
+      TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -882,18 +838,16 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_35, Probability: 34, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 33, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 33,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_35, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_057, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_35, Probability: 34, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 33, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Weapon_Lsword_057, DropGameData: IsVisitLocation.MinusField, IsCheclDropGameData: true, Probability: 33,
-      TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_35, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_53, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_057, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -915,12 +869,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 10
     MinNumberOfDropChance: 10
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -943,16 +899,16 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_183_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_29, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_183_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_036, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_183_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_29, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_183_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Lsword_036, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -980,16 +936,16 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_182_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_30, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_182_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_017, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_182_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_30, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_182_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_017, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -1016,16 +972,16 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_181_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_31, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_181_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Spear_027, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_181_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Obj_SubstituteCloth_31, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_181_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Spear_027, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -1046,16 +1002,18 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_184_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_32, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_32, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_184_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_029, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_026, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Armor_184_Head, DropGameData: GOToTheCastleOfHyrule_IsAfter_Ready_Exp, IsCheclDropGameData: true, Probability: 50,
-      TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Obj_SubstituteCloth_32, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_32, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_184_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Sword_029, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_026, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -1072,12 +1030,14 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_33, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_33, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Weapon_01, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_33, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_33, Probability: 99, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Item_Weapon_01, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
@@ -1096,12 +1056,16 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_34, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_34, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_005, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_34, Probability: 100, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_34, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Bow_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Weapon_Shield_005, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1


### PR DESCRIPTION
This PR is a major overhaul to the drop tables.

- Fabrics and armor should drop first since they stop appearing after they've been obtained.
- Weapons, bows, and shields should appear after all fabric and armor has been obtained.
- Progression requirements have been removed, so all items can be acquired as soon as amiibo can be used.

This new system works by increasing the probability of fabrics and armor to large similar values while decreasing the probability of weapons, bows, and shields to near zero values. For example, the Skyward Sword Link amiibo normally drops its fabric, armor pieces, and sword with the same probability. With this change, the fabric and armor pieces each have similar probability near 25% while the sword has a probability of 1%. Due to the way the game handles these probabilities, when a fabric or armor piece is obtained, it is removed from the drop table and the rest of the probabilities scale up.

The following tables explain the progression of the drop table after fabric and armor pieces have been obtained. It is of course not guaranteed that items will be acquired in order.

## Initial probability table

| Item        | Probability |
| ----------- | ----------: |
| Fabric      |        0.25 |
| Head Piece  |        0.25 |
| Torso Piece |        0.25 |
| Leg Piece   |        0.24 |
| Sword       |        0.01 |

## Once the fabric is obtained

| Item        | Probability |
| ----------- | ----------: |
| ~~Fabric~~  |    ~~0.00~~ |
| Head Piece  |        0.33 |
| Torso Piece |        0.33 |
| Leg Piece   |        0.32 |
| Sword       |        0.01 |

## Once the head piece is obtained

| Item           | Probability |
| -------------- | ----------: |
| ~~Fabric~~     |    ~~0.00~~ |
| ~~Head Piece~~ |    ~~0.00~~ |
| Torso Piece    |        0.50 |
| Leg Piece      |        0.48 |
| Sword          |        0.02 |

## Once the torso piece is obtained

| Item            | Probability |
| --------------- | ----------: |
| ~~Fabric~~      |    ~~0.00~~ |
| ~~Head Piece~~  |    ~~0.00~~ |
| ~~Torso Piece~~ |    ~~0.00~~ |
| Leg Piece       |        0.96 |
| Sword           |        0.04 |

## Once the leg piece is obtained

| Item            | Probability |
| --------------- | ----------: |
| ~~Fabric~~      |    ~~0.00~~ |
| ~~Head Piece~~  |    ~~0.00~~ |
| ~~Torso Piece~~ |    ~~0.00~~ |
| ~~Leg Piece~~   |    ~~0.00~~ |
| Sword           |        1.00 |
