### PR TITLE
Change armor amiibo drop tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixes
+
+- amiibo that drop armor will have the same chance to drop armor as they do
+  weapons, bows, and shields, which resolves an issue where armor would
+  continually drop.
+
 ## [2.0.0] - 2023-05-19
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -141,25 +141,25 @@ been corrupted by gloom.
 ### Daruk
 
 - **Goron-Champion Fabric**
-- **Vah Rudania Divine Helm**
+- Vah Rudania Divine Helm
 - Cobble Crusher✨
 
 ### Revali
 
 - **Rito-Champion Fabric**
-- **Vah Medoh Divine Helm**
+- Vah Medoh Divine Helm
 - Falcon Bow
 
 ### Mipha
 
 - **Zora-Champion Fabric**
-- **Vah Ruta Divine Helm**
+- Vah Ruta Divine Helm
 - Zora Spear✨
 
 ### Urbosa
 
 - **Gerudo-Champion Fabric**
-- **Vah Naboris Divine Helm**
+- Vah Naboris Divine Helm
 - Gerudo Scimitar✨
 - Gerudo Shield
 
@@ -177,17 +177,17 @@ been corrupted by gloom.
 ### Link's Awakening Link
 
 - **Egg Fabric**
-- **Mask of Awakening**
-- **Tunic of Awakening**
-- **Trousers of Awakening**
+- Mask of Awakening
+- Tunic of Awakening
+- Trousers of Awakening
 - Soldier's Broadsword✨
 
 ### Skyward Sword Link
 
 - **Sword-Spirit Fabric**
-- **Cap of the Sky**
-- **Tunic of the Sky**
-- **Trousers of the Sky**
+- Cap of the Sky
+- Tunic of the Sky
+- Trousers of the Sky
 - White Sword of the Sky
 
 ### Skyward Sword Zelda
@@ -198,9 +198,9 @@ been corrupted by gloom.
 ### Twilight Princess Link / Smash Bros. Link
 
 - **Mirror of Twilight Fabric**
-- **Cap of Twilight**
-- **Tunic of Twilight**
-- **Trousers of Twilight**
+- Cap of Twilight
+- Tunic of Twilight
+- Trousers of Twilight
 - Knight's Broadsword✨
 - Knight's Shield
 
@@ -212,9 +212,9 @@ been corrupted by gloom.
 ### Wind Waker Link / Smash Bros. Toon Link
 
 - **King of Red Lions Fabric**
-- **Cap of the Wind**
-- **Tunic of the Wind**
-- **Trousers of the Wind**
+- Cap of the Wind
+- Tunic of the Wind
+- Trousers of the Wind
 - Sea-Breeze Boomerang
 
 ### Wind Waker Zelda
@@ -225,25 +225,25 @@ been corrupted by gloom.
 ### Ocarina of Time Link / Smash Bros. Young Link
 
 - **Lon Lon Ranch Fabric**
-- **Cap of Time**
-- **Tunic of Time**
-- **Trousers of Time**
+- Cap of Time
+- Tunic of Time
+- Trousers of Time
 - Biggoron's Sword
 
 ### Majora's Mask Link
 
 - **Majora's Mask Fabric**
-- **Fierce Deity Mask**
-- **Fierce Deity Armor**
-- **Fierce Deity Boots**
+- Fierce Deity Mask
+- Fierce Deity Armor
+- Fierce Deity Boots
 - Fierce Deity Sword
 
 ### 8-Bit Link
 
 - **Pixel Fabric**
-- **Cap of the Hero**
-- **Tunic of the Hero**
-- **Trousers of the Hero**
+- Cap of the Hero
+- Tunic of the Hero
+- Trousers of the Hero
 - Sword of the Hero
 
 ### Smash Bros. Zelda
@@ -254,7 +254,7 @@ been corrupted by gloom.
 ### Smash Bros. Sheik
 
 - **Sheik Fabric**
-- **Sheik's Mask**
+- Sheik's Mask
 - Eightfold Blade✨
 - Shield of the Mind's Eye
 - Phrenic Bow

--- a/src/tables/AmiiboSetting.game__ui__AmiiboSetting.yml
+++ b/src/tables/AmiiboSetting.game__ui__AmiiboSetting.yml
@@ -35,7 +35,7 @@ AmiiboDropActorSettingSet:
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_1048
+  NumberingID: NumberingID_1048 # TotK Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Meat_01, Probability: 100}
@@ -61,7 +61,7 @@ AmiiboDropActorSettingSet:
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_1050
+  NumberingID: NumberingID_1050 # Unknown, Possibly TotK Ganondorf
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_PlantGet_A, Probability: 35}
@@ -98,7 +98,7 @@ AmiiboDropActorSettingSet:
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_1049
+  NumberingID: NumberingID_1049 # Unknown, Possibly TotK Zelda
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Animal_Fish_A, Probability: 12, TreasureBoxActorShort: ''}
@@ -141,7 +141,7 @@ AmiiboDropActorSettingSet:
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_851
+  NumberingID: NumberingID_851 # Archer Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Mushroom_E, Probability: 35}
@@ -175,7 +175,7 @@ AmiiboDropActorSettingSet:
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_852
+  NumberingID: NumberingID_852 # Rider Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_PlantGet_A, Probability: 35}
@@ -212,7 +212,7 @@ AmiiboDropActorSettingSet:
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_854
+  NumberingID: NumberingID_854 # BotW Zelda
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Meat_01, Probability: 90}
@@ -226,24 +226,24 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Lsword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Lsword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_843
+  NumberingID: NumberingID_843 # Ocarina of Time Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Mushroom_E, Probability: 35}
@@ -266,24 +266,24 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_41, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_41, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Lsword_060, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_41, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_225_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_41, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_225_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Lsword_060, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_844
+  NumberingID: NumberingID_844 # Majora's Mask Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Kibako_Contain_01, Probability: 100}
@@ -296,24 +296,24 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 4
     MinNumberOfDropChance: 2
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_45, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_45, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_057, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_45, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_215_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_45, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_215_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_057, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_846
+  NumberingID: NumberingID_846 # Skyward Sword Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Barrel, Probability: 100}
@@ -326,24 +326,24 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 3
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_46, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_46, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_058, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_46, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_230_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_46, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_230_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_058, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_847
+  NumberingID: NumberingID_847 # 8-Bit Link
 - AmiiboSpecialDeal: Epona
   DropActorInfoListSet:
   - DropActorInfo:
@@ -365,26 +365,26 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Upper, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 95, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Shield_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Upper, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 95, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Shield_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_4
+  NumberingID: NumberingID_4 # Smash Bros. Link
 - AmiiboSpecialDeal: Epona
   DropActorInfoListSet:
   - DropActorInfo:
@@ -406,26 +406,26 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Upper, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 95, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Shield_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Upper, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_210_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_38, Probability: 95, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_210_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Shield_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_003, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_845
+  NumberingID: NumberingID_845 # Twilight Princess Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Animal_Fish_A, Probability: 34}
@@ -448,24 +448,24 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_848
+  NumberingID: NumberingID_848 # Wind Waker Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Meat_01, Probability: 90}
@@ -479,24 +479,24 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Lsword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_200_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_40, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_200_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Lsword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_892
+  NumberingID: NumberingID_892 # Smash Bros. Young Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Barrel, Probability: 100}
@@ -509,24 +509,24 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 3
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_48, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_48, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_002, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_48, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_1096_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_48, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_1096_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_002, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_921
+  NumberingID: NumberingID_921 # Link's Awakening Link
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_PlantGet_A, Probability: 35}
@@ -561,7 +561,7 @@ AmiiboDropActorSettingSet:
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_850
+  NumberingID: NumberingID_850 # Wind Waker Zelda
 - AmiiboSpecialDeal: None
   DropActorInfoListSet:
   - DropActorInfo:
@@ -597,7 +597,7 @@ AmiiboDropActorSettingSet:
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_14
+  NumberingID: NumberingID_14 # Smash Bros. Zelda
 - DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_PlantGet_A, Probability: 35}
@@ -632,9 +632,9 @@ AmiiboDropActorSettingSet:
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
-  NumberingID: NumberingID_1044
+  NumberingID: NumberingID_1044 # Skyward Sword Zelda
 - AmiiboSetType: CharacterID
-  CharacterIDType: ToonLink
+  CharacterIDType: ToonLink # Smash Bros. Toon Link
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Animal_Fish_A, Probability: 34}
@@ -657,25 +657,25 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Head, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Upper, Probability: 25, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_205_Lower, Probability: 24, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_36, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Upper, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_205_Lower, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_059, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
 - AmiiboSetType: CharacterID
-  CharacterIDType: Sheik
+  CharacterIDType: Sheik # Smash Bros. Sheik
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Mushroom_E, Probability: 35}
@@ -698,8 +698,8 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_37, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_220_Head, Probability: 48, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_37, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_220_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_041, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Shield_041, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Bow_029, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
@@ -707,8 +707,8 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_37, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_220_Head, Probability: 48, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_37, Probability: 96, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_220_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_041, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Shield_041, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Bow_029, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
@@ -717,7 +717,7 @@ AmiiboDropActorSettingSet:
     MinNumberOfDropChance: 1
   NumberingID: Unknown
 - AmiiboSetType: CharacterBaseID
-  CharacterBaseIDType: Link
+  CharacterBaseIDType: Link # Unknown Link
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Animal_Fish_A, Probability: 34}
@@ -772,7 +772,7 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
 - AmiiboSetType: CharacterBaseID
-  CharacterBaseIDType: Zelda
+  CharacterBaseIDType: Zelda # Unknown Zelda
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_PlantGet_A, Probability: 35}
@@ -824,7 +824,7 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
 - AmiiboSetType: CharacterBaseID
-  CharacterBaseIDType: Ganon
+  CharacterBaseIDType: Ganon # Smash Bros. Ganondorf
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Meat_01, Probability: 100}
@@ -852,7 +852,7 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
 - AmiiboSetType: CharacterBaseID
-  CharacterBaseIDType: WolfLink
+  CharacterBaseIDType: WolfLink # Wolf Link
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Meat_01, Probability: 80}
@@ -881,7 +881,7 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
 - AmiiboSetType: CharacterBaseID
-  CharacterBaseIDType: Darukel
+  CharacterBaseIDType: Darukel # Daruk
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Ore_H, Probability: 60}
@@ -899,21 +899,21 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_29, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_183_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_29, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_183_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Lsword_036, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_29, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_183_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_29, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_183_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Lsword_036, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
 - AmiiboSetType: CharacterBaseID
-  CharacterBaseIDType: Reval
+  CharacterBaseIDType: Reval # Revali
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Fruit_A, Probability: 20}
@@ -936,21 +936,21 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_30, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_182_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_30, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_182_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Bow_017, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_30, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_182_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_30, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_182_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Bow_017, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
 - AmiiboSetType: CharacterBaseID
-  CharacterBaseIDType: Mifar
+  CharacterBaseIDType: Mifar # Mipha
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Animal_Fish_A, Probability: 34}
@@ -972,21 +972,21 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_31, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_181_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_31, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_181_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Spear_027, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_31, Probability: 50, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_181_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_31, Probability: 98, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_181_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Spear_027, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
 - AmiiboSetType: CharacterBaseID
-  CharacterBaseIDType: Uruboza
+  CharacterBaseIDType: Uruboza # Urbosa
   DropActorInfoListSet:
   - DropActorInfo:
     - {ActorNameShort: Item_Meat_01, Probability: 40}
@@ -1002,16 +1002,16 @@ AmiiboDropActorSettingSet:
     MaxNumberOfDropChance: 2
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_32, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_184_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_32, Probability: 97, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_184_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_029, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Shield_026, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: BigHit
     MaxNumberOfDropChance: 1
     MinNumberOfDropChance: 1
   - DropActorInfo:
-    - {ActorNameShort: Obj_SubstituteCloth_32, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
-    - {ActorNameShort: Armor_184_Head, Probability: 49, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Obj_SubstituteCloth_32, Probability: 97, TreasureBoxActorShort: TBox_Field_Iron}
+    - {ActorNameShort: Armor_184_Head, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Sword_029, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     - {ActorNameShort: Weapon_Shield_026, Probability: 1, TreasureBoxActorShort: TBox_Field_Iron}
     DropRsultType: GreatHit


### PR DESCRIPTION
This PR fixes an issue with amiibo that drop armor where they continually drop armor even after all armor has been obtained. Now armor has the same probability as weapons, bows, and shields. Fabric will stop drop first.